### PR TITLE
Align app services with refreshed database schema

### DIFF
--- a/src/screens/moderation/BlockedUsersScreen.tsx
+++ b/src/screens/moderation/BlockedUsersScreen.tsx
@@ -63,7 +63,7 @@ export default function BlockedUsersScreen() {
           onPress: async () => {
             try {
               await contentModerationService.unblockUser(blockedUserId);
-              setBlockedUsers(prev => prev.filter(user => user.blocked_user_id !== blockedUserId));
+              setBlockedUsers(prev => prev.filter(user => user.blocked_id !== blockedUserId));
               Alert.alert('Success', 'User has been unblocked');
             } catch (error) {
               console.error('Error unblocking user:', error);
@@ -98,7 +98,7 @@ export default function BlockedUsersScreen() {
       
       <TouchableOpacity
         style={styles.unblockButton}
-        onPress={() => handleUnblockUser(blockedUser.blocked_user_id)}
+        onPress={() => handleUnblockUser(blockedUser.blocked_id)}
       >
         <Ionicons name="person-add" size={20} color="#5B21B6" />
       </TouchableOpacity>

--- a/src/services/api/notificationService.ts
+++ b/src/services/api/notificationService.ts
@@ -91,7 +91,18 @@ class NotificationService {
   }): Promise<Notification> {
     const { data, error } = await supabase
       .from('notifications')
-      .insert(notification)
+      .insert({
+        user_id: notification.user_id,
+        sender_id: notification.sender_id,
+        type: notification.type,
+        title: notification.title,
+        body: notification.message,
+        message: notification.message,
+        prayer_id: notification.prayer_id,
+        group_id: notification.group_id,
+        metadata: notification.metadata || {},
+        payload: notification.metadata || {},
+      })
       .select(`
         *,
         sender:profiles!sender_id(*),

--- a/src/services/api/prayerInteractionService.ts
+++ b/src/services/api/prayerInteractionService.ts
@@ -264,6 +264,9 @@ class PrayerInteractionService {
         prayer_id: prayerId,
         user_id: user.id,
         reminder_time: reminderTime.toISOString(),
+        frequency: 'daily',
+        is_active: true,
+        is_sent: false,
       });
 
     if (error) throw error;

--- a/src/services/api/prayerService.ts
+++ b/src/services/api/prayerService.ts
@@ -286,6 +286,8 @@ class PrayerService {
           prayer_id: prayerId,
           user_id: user.id,
           reminder_time: reminderTime.toISOString(),
+          frequency: 'daily',
+          is_active: true,
           is_sent: false,
         });
 

--- a/src/services/api/supportService.ts
+++ b/src/services/api/supportService.ts
@@ -18,11 +18,11 @@ export interface SupportTicket {
 export interface SupportMessage {
   id: string;
   ticket_id: string;
-  user_id: string;
+  sender_id: string;
   message: string;
-  is_admin: boolean;
-  created_at: string;
+  is_from_support: boolean;
   attachments?: string[];
+  created_at: string;
 }
 
 /**
@@ -121,9 +121,9 @@ class SupportService {
       .from('support_messages')
       .insert({
         ticket_id: ticketId,
-        user_id: user.id,
+        sender_id: user.id,
         message,
-        is_admin: false,
+        is_from_support: false,
         attachments: attachments || [],
       })
       .select()

--- a/src/services/notifications/notificationManager.ts
+++ b/src/services/notifications/notificationManager.ts
@@ -1,6 +1,7 @@
 import { useNotificationStore } from '@/store/notification/notificationStore';
 import { pushNotificationService } from './pushNotificationService';
 import { notificationService } from '@/services/api/notificationService';
+import { supabase } from '@/config/supabase';
 
 /**
  * Notification Manager - Coordinates notification system
@@ -73,7 +74,7 @@ class NotificationManager {
   ): Promise<void> {
     try {
       // Create notification in database
-      const createdNotification = await notificationService.createNotification({
+      await notificationService.createNotification({
         user_id: userId,
         sender_id: notification.sender_id,
         type: notification.type,
@@ -192,7 +193,6 @@ class NotificationManager {
       .from('group_members')
       .select('user_id')
       .eq('group_id', groupId)
-      .eq('status', 'active')
       .neq('user_id', updaterId);
 
     if (members) {

--- a/src/services/search/searchService.ts
+++ b/src/services/search/searchService.ts
@@ -105,10 +105,6 @@ class SearchService {
       queryBuilder = queryBuilder.eq('privacy_level', filters.prayerPrivacy);
     }
 
-    if (filters.prayerCategory) {
-      queryBuilder = queryBuilder.eq('category', filters.prayerCategory);
-    }
-
     if (filters.prayerTags && filters.prayerTags.length > 0) {
       queryBuilder = queryBuilder.overlaps('tags', filters.prayerTags);
     }
@@ -127,21 +123,14 @@ class SearchService {
         queryBuilder = queryBuilder.eq('location_city', filters.location.city);
       }
       
-      if (filters.location.lat && filters.location.lon && filters.location.radius) {
-        // Use PostGIS for location-based search
-        queryBuilder = queryBuilder.rpc('search_prayers_by_location', {
-          lat: filters.location.lat,
-          lon: filters.location.lon,
-          radius_km: filters.location.radius,
-        });
-      }
+      // Advanced radius-based search requires server-side support; fallback to city filter
     }
 
     // Exclude blocked users if not including them
     if (!includeBlocked) {
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
-        queryBuilder = queryBuilder.not('user_id', 'in', `(SELECT blocked_user_id FROM blocked_users WHERE blocker_id = '${user.id}')`);
+        queryBuilder = queryBuilder.not('user_id', 'in', `(SELECT blocked_id FROM blocked_users WHERE blocker_id = '${user.id}')`);
       }
     }
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -53,6 +53,11 @@ export interface Database {
         Insert: Omit<Report, 'id' | 'created_at'>;
         Update: Partial<Omit<Report, 'id'>>;
       };
+      content_filters: {
+        Row: ContentFilter;
+        Insert: Omit<ContentFilter, 'id' | 'created_at'>;
+        Update: Partial<Omit<ContentFilter, 'id'>>;
+      };
       user_analytics: {
         Row: UserAnalytic;
         Insert: Omit<UserAnalytic, 'id' | 'created_at'>;
@@ -95,6 +100,10 @@ export interface Profile {
   onboarding_completed: boolean;
   email_notifications: boolean;
   push_notifications: boolean;
+  push_token?: string;
+  push_token_updated_at?: string;
+  is_verified: boolean;
+  last_active?: string;
   created_at: string;
   updated_at: string;
 }
@@ -224,10 +233,15 @@ export interface Comment {
 export interface Notification {
   id: string;
   user_id: string;
+  sender_id?: string;
+  prayer_id?: string;
+  group_id?: string;
   type: NotificationType;
   title: string;
   body: string;
+  message?: string;
   payload: Record<string, any>;
+  metadata?: Record<string, any>;
   action_url?: string;
   read: boolean;
   sent_push: boolean;
@@ -254,10 +268,12 @@ export interface SupportTicket {
   user_id: string;
   subject: string;
   description: string;
-  category: 'bug' | 'feature' | 'account' | 'content' | 'other';
+  category: 'bug' | 'feature' | 'feature_request' | 'account' | 'billing' | 'content' | 'other';
   priority: 'low' | 'medium' | 'high' | 'urgent';
-  status: 'open' | 'pending' | 'resolved' | 'closed';
+  status: 'open' | 'pending' | 'in_progress' | 'resolved' | 'closed';
   assigned_to?: string;
+  attachments?: string[];
+  admin_notes?: string;
   satisfaction_rating?: number;
   satisfaction_feedback?: string;
   created_at: string;
@@ -281,6 +297,15 @@ export interface Report {
   resolved_at?: string;
 }
 
+export interface ContentFilter {
+  id: string;
+  user_id: string;
+  filter_type: 'keyword' | 'user' | 'category';
+  filter_value: string;
+  is_active: boolean;
+  created_at: string;
+}
+
 // User Analytics
 export interface UserAnalytic {
   id: string;
@@ -288,6 +313,9 @@ export interface UserAnalytic {
   event_type: string;
   event_data: Record<string, any>;
   session_id?: string;
+  platform?: string;
+  app_version?: string;
+  timestamp: string;
   created_at: string;
 }
 
@@ -304,6 +332,7 @@ export interface BlockedUser {
   id: string;
   blocker_id: string;
   blocked_id: string;
+  reason?: string;
   created_at: string;
 }
 
@@ -323,8 +352,11 @@ export interface PrayerReminder {
   prayer_id: string;
   user_id: string;
   reminder_time: string;
+  frequency: 'none' | 'daily' | 'weekly';
+  is_active: boolean;
   is_sent: boolean;
   created_at: string;
+  updated_at: string;
   // Joined data
   prayer?: Prayer;
   user?: Profile;


### PR DESCRIPTION
## Summary
- extend the SQL schema to cover push tokens, enriched notifications, support ticket attachments, analytics metrics, content filters, and additional moderation fields
- update shared TypeScript types and service layers (notifications, support, prayer reminders, analytics, content moderation, search) to match the revised schema contracts
- fix blocked user handling, group notification queries, and analytics aggregation so features no longer reference missing columns or tables

## Testing
- npm run lint *(fails: ESLint requires migrating to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c9aa42550483328d7b6272c203cbdb